### PR TITLE
Fix typo in item routes messages

### DIFF
--- a/routes/item.routes.js
+++ b/routes/item.routes.js
@@ -86,12 +86,12 @@ router.get('/:skuNumber', async (req, res) => {
     if (!itemFond) {
       res.json({
         success: false,
-        message: `item not fond (${skuNumber})`
+        message: `item not found (${skuNumber})`
       });
     } else {
       res.json({
         success: true,
-        message: `Location fond `,
+        message: `Item found`,
         item: itemFond
       });
     }


### PR DESCRIPTION
## Summary
- correct typo in `routes/item.routes.js` messages near the `/:skuNumber` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859ece2ec8c83279510cc0cce4fbb7f