### PR TITLE
Add cleanItem helper tests

### DIFF
--- a/helper/cleanItem.js
+++ b/helper/cleanItem.js
@@ -48,3 +48,11 @@ function getAllData(fullData) {
 }
 
 module.exports = getAllData;
+module.exports.getAllData = getAllData;
+module.exports.removeSpaces = removeSpaces;
+module.exports.getLocation = getLocation;
+module.exports.getItemNumber = getItemNumber;
+module.exports.getModel = getModel;
+module.exports.getUpc = getUpc;
+module.exports.getImgUrl = getImgUrl;
+module.exports.cutString = cutString;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "server": "nodemon server.js",
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
-    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client"
+    "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run build --prefix client",
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
@@ -52,6 +53,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.2",
     "prettier": "^1.18.2",
-    "concurrently": "^4.1.0"
+    "concurrently": "^4.1.0",
+    "jest": "^30.0.2"
   }
 }

--- a/test/cleanItem.test.js
+++ b/test/cleanItem.test.js
@@ -1,0 +1,49 @@
+const helper = require('../helper/cleanItem');
+
+describe('cleanItem helper functions', () => {
+  const sampleInput = 'Item #: 12345 Model : MD01 UPC: 54321';
+  const noSpaces = 'Item#:12345Model:MD01UPC:54321';
+
+  test('removeSpaces removes all whitespace', () => {
+    expect(helper.removeSpaces(sampleInput)).toBe(noSpaces);
+  });
+
+  test('getLocation finds index of substring', () => {
+    expect(helper.getLocation('Hello World', 'World')).toBe(6);
+  });
+
+  test('getItemNumber extracts item number', () => {
+    const result = helper.getItemNumber(noSpaces);
+    expect(result.itemNumber).toBe('12345');
+    expect(result.endLocation).toBe(noSpaces.indexOf('Model'));
+  });
+
+  test('getModel extracts model id', () => {
+    const modelString = 'Model:MD01UPC:54321';
+    const result = helper.getModel(modelString);
+    expect(result.modelId).toBe('MD01');
+    expect(result.endModelLocation).toBe(modelString.indexOf('UPC'));
+  });
+
+  test('getUpc strips UPC prefix', () => {
+    expect(helper.getUpc('UPC:54321')).toBe('54321');
+  });
+
+  test('cutString returns substring from position', () => {
+    expect(helper.cutString(noSpaces, noSpaces.indexOf('Model'))).toBe('Model:MD01UPC:54321');
+  });
+
+  test('getImgUrl builds image url', () => {
+    expect(helper.getImgUrl('12345')).toBe('http://cranbury.worldandmain.com/img/items/12345_1.jpg');
+  });
+
+  test('getAllData parses full data string', () => {
+    const result = helper.getAllData(sampleInput);
+    expect(result).toEqual({
+      img: 'http://cranbury.worldandmain.com/img/items/12345_1.jpg',
+      itemNumber: '12345',
+      model: 'MD01',
+      upc: '54321'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export helper functions from `cleanItem.js`
- add Jest setup and tests for cleanItem helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ee28705c832781d2b9ef4299ddc4