### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd wms
 npm install
 ```
 
-Change to the `client` folder and install development and producation dependencies.
+Change to the `client` folder and install development and production dependencies.
 ```
 cd client
 npm install


### PR DESCRIPTION
## Summary
- fix a typo in the installation instructions

## Testing
- `grep -n "production depend" README.md`

------
https://chatgpt.com/codex/tasks/task_e_6859ee1efa2083279bcc4cfa52c5fed0