### PR TITLE
Fix global variable in location creation

### DIFF
--- a/routes/location.routes.js
+++ b/routes/location.routes.js
@@ -86,7 +86,7 @@ router.get('/create', async (req, res) => {
 });
 
 router.post('/create', async (req, res) => {
-  newLocation = new Location({ ...req.body });
+  const newLocation = new Location({ ...req.body });
   newLocation.maxSize = newLocation.size;
   newLocation.size = 0;
   const { zone, row, location, level } = newLocation;


### PR DESCRIPTION
## Summary
- ensure `newLocation` is a local constant when creating a location

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859ee047ec883279174f0d7050cd20e